### PR TITLE
profile upgrade

### DIFF
--- a/logic/backupLogic.js
+++ b/logic/backupLogic.js
@@ -7,15 +7,18 @@ module.exports = class BackupLogic {
 
   static types = {
     PROFILE_IMAGE: 'PROFILE_IMAGE',
+    COVER_IMAGE: 'COVER_IMAGE'
   };
 
-  static async backupProfileImageToIPFS (imagePath, publicKey) {
+  static async backupImageToIPFS (imagePath, publicKey, type) {
     const buffer = fs.readFileSync(imagePath);
     const results = await ipfs.addFile(buffer);
+    if(!BackupLogic.types.hasOwnProperty(type)) throw TypeError('Unknown type: ' + type)
     IPFSEntry.create({
-      type: this.types.PROFILE_IMAGE,
+      type,
       hash: results[0].path,
       reference: publicKey
     });
   }
+
 };

--- a/logic/profileLogic.js
+++ b/logic/profileLogic.js
@@ -7,78 +7,65 @@ const { Profile } = require('../models');
 
 module.exports = class ProfileLogic {
 
-  static async createProfile (req, res) {
+  static async upsertProfile(req, res) {
     try {
-      const { author, biography, preferredChainName, referrer, signature, challenge } = req.body;
+      const { biography, preferredChainName, referrer, location, signature, challenge } = req.body;
+      let { image, coverImage } = (req.files ? req.files : {});
+      // allow image deletion
+      if(!image && req.body.image === null) image = [{ filename: null }];
+      if(!coverImage && req.body.coverImage === null) coverImage = [{ filename: null }];
+      // get author
+      const author = req.body.author ? req.body.author : (req.params.author ? req.params.author : null);
       if (!author) return res.status(400).send('Missing required field author');
       const existing = await Profile.findOne({ where: { author }, raw: true });
-      if (existing) return await ProfileLogic.updateProfile(req, res)
-      const entry = await Profile.create({ author, biography, preferredChainName, referrer, signature, challenge });
-      res.send(entry);
-
+      // Backup to IPFS
+      if (existing) {
+        await Profile.update({
+          ...(typeof biography !== 'undefined') && { biography },
+          ...(typeof preferredChainName !== 'undefined') && { preferredChainName },
+          ...(typeof referrer !== 'undefined') && { referrer },
+          ...(typeof location !== 'undefined') && { location },
+          ...(typeof image !== 'undefined') && { image: image[0].filename },
+          ...(typeof coverImage !== 'undefined') && { coverImage: coverImage[0].filename },
+          signature,
+          challenge,
+        }, { where: { author } });
+        if (image && existing.image && existing.image !== image[0].filename) fs.unlinkSync('images/' + existing.image);
+        if (coverImage && existing.coverImage && existing.coverImage !== coverImage[0].filename) fs.unlinkSync('images/' + existing.coverImage);
+      } else {
+        await Profile.create({
+          author,
+          biography,
+          preferredChainName,
+          referrer,
+          signature,
+          challenge,
+          image: image ? image[0].filename : null,
+          coverImage: coverImage ? coverImage[0].filename : null,
+          location,
+        });
+      }
+      if(image && image[0].filename !== null) await BackupLogic.backupImageToIPFS('images/' + image[0].filename, author, BackupLogic.types.PROFILE_IMAGE);
+      if(coverImage && coverImage[0].filename !== null) await BackupLogic.backupImageToIPFS('images/' + coverImage[0].filename, author, BackupLogic.types.COVER_IMAGE);
+      return ProfileLogic.getSingleItem(req, res);
     } catch (e) {
       console.error(e);
       res.status(500).send(e.message);
     }
   }
 
-  static async removeItem (req, res) {
-    const result = await Profile.destroy({
-      where: {
-        author: req.params.author,
-      },
-    });
-    return result === 1 ? res.sendStatus(200) : res.sendStatus(404);
-  }
-
-  static async getSingleItem (req, res) {
-    let result = await Profile.findOne({ where: { author: req.params.author }});
+  static async getSingleItem(req, res) {
+    const author = req.body.author ? req.body.author : (req.params.author ? req.params.author : null);
+    let result = await Profile.findOne({ where: { author } });
     if (!result) return res.sendStatus(404);
     result = result.toJSON();
-    result.image = !!result.image;
+    result.image = result.image ? `/images/${result.image}` : false;
+    result.coverImage = result.coverImage ? `/images/${result.coverImage}` : false;
     result.referrer = !!result.referrer;
     return res.send(result);
   };
 
-  static async updateProfile (req, res) {
-    const { author, biography, preferredChainName, referrer, signature, challenge } = req.body;
-    await Profile.update({
-      ...(typeof biography !== 'undefined') && { biography },
-      ...(typeof preferredChainName !== 'undefined') && { preferredChainName },
-      ...(typeof referrer !== 'undefined') && { referrer },
-      signature,
-      challenge,
-    }, { where: { author } });
-    return res.send((await Profile.findOne({ where: { author }})).toJSON())
-  }
-
-  static async getImage (req, res) {
-    const result = await Profile.findOne({ where: { author: req.params.author }, raw: true });
-    if (!result || !result.image) return res.sendStatus(404);
-    res.sendFile(path.resolve(__dirname, '../images', result.image));
-  }
-
-  static async updateImage (req, res) {
-    let result = await Profile.findOne({ where: { author: req.params.author }, raw: true });
-    if (!result) {
-      result = await Profile.create({
-        author: req.params.author,
-        signature: req.body.signature,
-        challenge: req.body.challenge,
-      });
-    }
-    if (!req.file) return res.status(400).send({ err: 'Could not find any image in your request.' });
-    // Delete existing image
-    if (result.image && result.image !== req.file.filename) fs.unlinkSync('images/' + result.image);
-    await BackupLogic.backupProfileImageToIPFS('images/' + req.file.filename, result.author);
-    await Profile.update({
-      image: `${req.file.filename}`,
-      imageSignature: req.body.signature,
-      imageChallenge: req.body.challenge,
-    }, { where: { author: req.params.author }, raw: true });
-    return ProfileLogic.getSingleItem(req, res);
-  }
-
+  // LEGACY
   static async deleteImage (req, res) {
     const result = await Profile.findOne({ where: { author: req.params.author }, raw: true });
     if (!result || !result.image) return res.sendStatus(404);
@@ -91,10 +78,16 @@ module.exports = class ProfileLogic {
     res.sendStatus(200);
   }
 
-  static async verifyRequest (req, res, next) {
+  static async getImage(req, res) {
+    const result = await Profile.findOne({ where: { author: req.params.author }, raw: true });
+    if (!result || !result.image) return res.sendStatus(404);
+    res.sendFile(path.resolve(__dirname, '../images', result.image));
+  }
+
+  static async verifyRequest(req, res, next) {
     // Get author
     const author = req.params.author ? req.params.author : req.body.author;
-    if(!author) return res.status(400).send({err: 'Missing author'});
+    if (!author) return res.status(400).send({ err: 'Missing author' });
 
     // No chain name
     if (typeof req.body.preferredChainName === 'undefined') return next();
@@ -104,8 +97,7 @@ module.exports = class ProfileLogic {
       .reduce((acc, curr) => [...acc, curr.name], []);
 
     // check if chain name points to author
-    return chainNames.includes(req.body.preferredChainName) ? next() : res.status(400).send({err: 'Chainname does not point to author'})
-
+    return chainNames.includes(req.body.preferredChainName) ? next() : res.status(400).send({ err: 'Chainname does not point to author' });
 
   }
 };

--- a/migrations/11-update-profile.js
+++ b/migrations/11-update-profile.js
@@ -1,0 +1,115 @@
+'use strict';
+
+var Sequelize = require('sequelize');
+
+/**
+ * Actions summary:
+ *
+ * addColumn "coverImage" to table "Profiles"
+ * addColumn "location" to table "Profiles"
+ *
+ **/
+
+var info = {
+    "revision": 11,
+    "name": "update-profile",
+    "created": "2020-06-23T14:50:08.829Z",
+    "comment": ""
+};
+
+var migrationCommands = function(transaction) {
+    return [{
+            fn: "addColumn",
+            params: [
+                "Profiles",
+                "coverImage",
+                {
+                    "type": Sequelize.STRING,
+                    "field": "coverImage",
+                    "allowNull": true
+                },
+                {
+                    transaction: transaction
+                }
+            ]
+        },
+        {
+            fn: "addColumn",
+            params: [
+                "Profiles",
+                "location",
+                {
+                    "type": Sequelize.STRING,
+                    "field": "location",
+                    "allowNull": true
+                },
+                {
+                    transaction: transaction
+                }
+            ]
+        }
+    ];
+};
+var rollbackCommands = function(transaction) {
+    return [{
+            fn: "removeColumn",
+            params: [
+                "Profiles",
+                "coverImage",
+                {
+                    transaction: transaction
+                }
+            ]
+        },
+        {
+            fn: "removeColumn",
+            params: [
+                "Profiles",
+                "location",
+                {
+                    transaction: transaction
+                }
+            ]
+        }
+    ];
+};
+
+module.exports = {
+    pos: 0,
+    useTransaction: true,
+    execute: function(queryInterface, Sequelize, _commands)
+    {
+        var index = this.pos;
+        function run(transaction) {
+            const commands = _commands(transaction);
+            return new Promise(function(resolve, reject) {
+                function next() {
+                    if (index < commands.length)
+                    {
+                        let command = commands[index];
+                        console.log("[#"+index+"] execute: " + command.fn);
+                        index++;
+                        queryInterface[command.fn].apply(queryInterface, command.params).then(next, reject);
+                    }
+                    else
+                        resolve();
+                }
+                next();
+            });
+        }
+        if (this.useTransaction) {
+            return queryInterface.sequelize.transaction(run);
+        } else {
+            return run(null);
+        }
+    },
+    up: function(queryInterface, Sequelize)
+    {
+        return this.execute(queryInterface, Sequelize, migrationCommands);
+    },
+    down: function(queryInterface, Sequelize)
+    {
+        return this.execute(queryInterface, Sequelize, rollbackCommands);
+    },
+    info: info
+};

--- a/migrations/_current.json
+++ b/migrations/_current.json
@@ -327,6 +327,16 @@
                     "field": "referrer",
                     "seqType": "Sequelize.STRING"
                 },
+                "location": {
+                    "allowNull": true,
+                    "field": "location",
+                    "seqType": "Sequelize.STRING"
+                },
+                "coverImage": {
+                    "allowNull": true,
+                    "field": "coverImage",
+                    "seqType": "Sequelize.STRING"
+                },
                 "signature": {
                     "allowNull": false,
                     "field": "signature",
@@ -426,5 +436,5 @@
             "indexes": []
         }
     },
-    "revision": 10
+    "revision": 11
 }

--- a/models/profile.js
+++ b/models/profile.js
@@ -22,6 +22,14 @@ module.exports = (sequelize, DataTypes) => {
       type: DataTypes.STRING,
       allowNull: true,
     },
+    location: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
+    coverImage: {
+      type: DataTypes.STRING,
+      allowNull: true,
+    },
     signature: {
       type: DataTypes.STRING,
       allowNull: false,

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -7,23 +7,27 @@ const path = require('path');
 const router = new Router();
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
-    cb(null, 'images/')
+    cb(null, 'images/');
   },
   filename: function (req, file, cb) {
-    cb(null,`${req.params.author}-${Date.now()}${path.extname(file.originalname)}`) //Appending extension
-  }
+    cb(null, `${req.params.author}-${Date.now()}${path.extname(file.originalname)}`); //Appending extension
+  },
 });
 const upload = multer({ storage });
 
 
 // Open api routes
 router.get('/:author', ProfileLogic.getSingleItem);
-router.post('/', signatureAuth, ProfileLogic.verifyRequest, ProfileLogic.createProfile);
-// router.delete('/:author', signatureAuth, ProfileLogic.verifyRequest, ProfileLogic.removeItem);
+router.post('/:author', upload.fields([{ name: 'image', maxCount: 1 }, { name: 'coverImage', maxCount: 1, }]), signatureAuth, ProfileLogic.verifyRequest, ProfileLogic.upsertProfile);
 
-// Image Routes
+// Image routes
 router.get('/image/:author', ProfileLogic.getImage);
-router.post('/image/:author', upload.single('image'), signatureAuth, ProfileLogic.verifyRequest, ProfileLogic.updateImage);
+
+
+// Legacy routes
+router.post('/image/:author', upload.fields([{ name: 'image', maxCount: 1 }, { name: 'coverImage', maxCount: 1, }]), signatureAuth, ProfileLogic.verifyRequest, ProfileLogic.upsertProfile);
 router.delete('/image/:author', signatureAuth, ProfileLogic.verifyRequest, ProfileLogic.deleteImage);
+router.post('/', upload.fields([{ name: 'image', maxCount: 1 }, { name: 'coverImage', maxCount: 1, }]), signatureAuth, ProfileLogic.verifyRequest, ProfileLogic.upsertProfile);
+
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ app.use('/profile', require('./routes/profileRoutes.js'));
 app.use('/errorreport', require('./routes/errorReportRoutes.js'));
 app.use('/tracing', require('./routes/tipTracingRoutes.js'));
 app.use('/health', require('./routes/healthRoutes.js'));
+app.use('/images', express.static('./images'));
 
 app.use((req, res) => {
   res.sendStatus(404);

--- a/test/auth.js
+++ b/test/auth.js
@@ -1,0 +1,101 @@
+//Require the dev-dependencies
+let chai = require('chai');
+let chaiHttp = require('chai-http');
+let server = require('../server');
+let should = chai.should();
+
+const {
+  shouldBeValidChallengeResponse,
+  signChallenge,
+  publicKey,
+  performSignedJSONRequest,
+} = require('../utils/testingUtil');
+
+
+chai.use(chaiHttp);
+//Our parent block
+describe('Authenticator', () => {
+
+  const testData = {
+    biography: 'What an awesome bio',
+    preferredChainName: 'awesomename.chain',
+    referrer: 'ak_aNTSYaqHmuSfKgBPjBm95eJz82JXKznCZVdchKKKh7jtDAJcW',
+    author: publicKey,
+    location: 'awesome, location, country',
+  };
+
+  describe('Profile Authentication', () => {
+    it('it should return a signature challenge', (done) => {
+      chai.request(server).post('/profile/' + publicKey ).send(testData).end((err, res) => {
+        res.should.have.status(200);
+        shouldBeValidChallengeResponse(res.body, testData);
+        done();
+      });
+    });
+
+    it('it should fail with invalid signature', (done) => {
+      chai.request(server).post('/profile/' + publicKey ).send(testData).end((err, res) => {
+        res.should.have.status(200);
+        shouldBeValidChallengeResponse(res.body, testData);
+
+        const challenge = res.body.challenge;
+        chai.request(server).post('/profile/' + publicKey ).send({ challenge, signature: 'wrong' }).end((err, res) => {
+          res.should.have.status(401);
+          res.body.should.be.a('object');
+          res.body.should.have.property('err', 'bad signature size');
+          done();
+        });
+      });
+    });
+
+    it('it should fail on invalid challenge', (done) => {
+      chai.request(server).post('/profile/' + publicKey ).send(testData).end((err, res) => {
+        res.should.have.status(200);
+        shouldBeValidChallengeResponse(res.body, testData);
+        const challenge = res.body.challenge;
+        const signature = signChallenge(challenge);
+        chai.request(server).post('/profile/' + publicKey ).send({
+          challenge: challenge.substring(2),
+          signature,
+        }).end((err, res) => {
+          res.should.have.status(401);
+          res.body.should.be.a('object');
+          res.body.should.have.property('err', 'Could not find challenge (maybe it already expired?)');
+          done();
+        });
+      });
+    });
+
+    it('it should fail at a change of paths', (done) => {
+      chai.request(server).post('/profile/' + publicKey ).send(testData).end((err, res) => {
+        res.should.have.status(200);
+        shouldBeValidChallengeResponse(res.body, testData);
+        const challenge = res.body.challenge;
+        const signature = signChallenge(challenge);
+        chai.request(server).post('/profile/' ).send({
+          challenge: challenge,
+          signature,
+        }).end((err, res) => {
+          res.should.have.status(401);
+          res.body.should.be.a('object');
+          res.body.should.have.property('err', 'Challenge was issued for a different path');
+          done();
+        });
+      });
+    });
+
+    it('it should reject creation for someone elses public key', (done) => {
+      performSignedJSONRequest(server, 'post', '/profile/ak_fUq2NesPXcYZ1CcqBcGC3StpdnQw3iVxMA3YSeCNAwfN4myQk', {
+        biography: 'new bio',
+      }).then(({ res }) => {
+        res.should.have.status(401);
+        res.body.should.be.a('object');
+        res.body.should.have.property('err', 'Invalid signature');
+        done();
+      });
+    });
+  });
+});
+
+
+

--- a/utils/testingUtil.js
+++ b/utils/testingUtil.js
@@ -1,6 +1,10 @@
 const { signPersonalMessage, generateKeyPair, hash } = require('@aeternity/aepp-sdk').Crypto;
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+chai.use(chaiHttp);
+const fs = require('fs');
 
- const { publicKey, secretKey } = generateKeyPair();
+const { publicKey, secretKey } = generateKeyPair();
 
 const signChallenge = (challenge, privateKey = null) => {
   if (!privateKey) privateKey = secretKey;
@@ -11,7 +15,61 @@ const signChallenge = (challenge, privateKey = null) => {
   return Buffer.from(signatureBuffer).toString('hex');
 };
 
+const shouldBeValidChallengeResponse = (serverBody, testData) => {
+  serverBody.should.be.a('object');
+  serverBody.should.have.property('challenge');
+  serverBody.should.have.property('payload');
+  Object.keys(testData).map(key => {
+    serverBody.payload.should.contain(`${key}=${testData[key]}`);
+  });
+};
+
+const performSignedMultipartFormRequest = (server, method, url, field, path, privateKey = null) => {
+  return new Promise((resolve, reject) => {
+    chai.request(server)[method](url)
+      .field('Content-Type', 'multipart/form-data')
+      .attach(field, path)
+      .end((err, res) => {
+        res.should.have.status(200);
+        shouldBeValidChallengeResponse(res.body, {
+          [field]: hash(fs.readFileSync(path)).toString('hex')
+        });
+        const challenge = res.body.challenge;
+        const signature = signChallenge(challenge, privateKey);
+        chai.request(server)[method](url).send({
+          challenge: challenge,
+          signature,
+        }).end((err, res) => {
+            if (err) return reject(err);
+            return resolve({ res, signature, challenge });
+          });
+      });
+  });
+};
+
+const performSignedJSONRequest = (server, method, url, data, privateKey = null) => {
+  return new Promise((resolve, reject) => {
+    chai.request(server)[method](url)
+      .send(data)
+      .end((err, res) => {
+        res.should.have.status(200);
+        shouldBeValidChallengeResponse(res.body, data);
+        const challenge = res.body.challenge;
+        const signature = signChallenge(challenge, privateKey);
+        chai.request(server)[method](url)
+          .send({ challenge, signature })
+          .end((err, res) => {
+            if (err) return reject(err);
+            return resolve({ res, signature, challenge });
+          });
+      });
+  });
+};
+
 module.exports = {
   publicKey,
-  signChallenge
-}
+  signChallenge,
+  shouldBeValidChallengeResponse,
+  performSignedJSONRequest,
+  performSignedMultipartFormRequest
+};


### PR DESCRIPTION
- adds two new fields: `location` and `coverImage`
- refactors tests
- adds around 20 new tests
- keeps api backwards compatible but:


`POST /profile/:author` now is the universal endpoint use it to create, update or delete any field in the profile
`POST /profile/image/:author` is deprecated and just an alias for `POST /profile/:author`
`POST /profile/` with author in the body is deprecated and just an alias for `POST /profile/:author`
`DELETE /profile/image/:author` is now deprecated. use POST `/profile/:author` with body `{ image: null }` instead
`GET /profile/:author` now returns URLs to the images instead of a boolean. eg:
```
{
	"image": "/images/ak_5wrHf8QSXscHDev1Nwje39mNzx4HFqGFCz8zyHcmfjv2ePFhB-1593092447712.png"
}
```
These images can then obviously be opened directly (https://backend/images/ak_5wrH(...).png).