### PR TITLE
fix(cache): remove undefined function from keephot

### DIFF
--- a/modules/cache/logic/cacheLogic.js
+++ b/modules/cache/logic/cacheLogic.js
@@ -23,7 +23,6 @@ module.exports = class CacheLogic {
 
     const keepHotFunction = async () => {
       await CacheLogic.getTips();
-      await CacheLogic.getAllTips(true); // only keep the blacklisted cache hot
       await CacheLogic.fetchChainNames();
       await CacheLogic.fetchPrice();
       await CacheLogic.getOracleState();


### PR DESCRIPTION
this function can not be simply required back in because it would result in a circular dependency