### PR TITLE
refactor: modules instead of classes - part 1

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
   },
   parser: 'babel-eslint',
   rules: {
+    'no-use-before-define': 'off',
     'no-extend-native': 'off',
     'max-len': ['error', { code: 150 }],
     'import/no-extraneous-dependencies': ['error', { devDependencies: true }],

--- a/bin/www.js
+++ b/bin/www.js
@@ -10,6 +10,7 @@ const broker = require('../modules/queue/logic/messageBrokerLogic');
 const queueLogic = require('../modules/queue/logic/queueLogic');
 const cacheLogic = require('../modules/cache/logic/cacheLogic');
 const chainListenerLogic = require('../modules/aeternity/logic/chainListenerLogic');
+const ipfsLogic = require('../modules/backup/logic/ipfsLogic');
 
 process
   .on('unhandledRejection', reason => {
@@ -63,6 +64,7 @@ const startup = async () => {
   await cache.init(aeternity);
   await cacheLogic.init();
   await chainListenerLogic.startInvalidator();
+  ipfsLogic.init();
 
   server.listen(port);
   server.on('error', onError);

--- a/modules/aeternity/logic/aeternity.js
+++ b/modules/aeternity/logic/aeternity.js
@@ -104,7 +104,7 @@ class Aeternity {
       { name: 'PostWithoutTipReceived', types: [SOPHIA_TYPES.address, SOPHIA_TYPES.string] },
     ];
 
-    return (decodeEvents(log, { schema: eventsSchema }) || []).map(decodedEvent => {
+    return (log ? decodeEvents(log, { schema: eventsSchema }) : []).map(decodedEvent => {
       const event = {};
       switch (decodedEvent.name) {
         // AEX9

--- a/modules/authentication/constants/actions.js
+++ b/modules/authentication/constants/actions.js
@@ -1,0 +1,104 @@
+const { Profile } = require('../../../models');
+
+const ACTIONS = [
+  {
+    method: 'GET',
+    path: '/notification/user/ak_',
+    actionName: 'GET_NOTIFICATIONS',
+    relevantFields: ['author'],
+  },
+  {
+    method: 'GET',
+    path: '/consent/ak_',
+    actionName: 'GET_CONSENT',
+    relevantFields: ['author'],
+  },
+  {
+    method: 'POST',
+    path: '/comment/api/?',
+    actionName: 'CREATE_COMMENT',
+    relevantFields: ['text', 'tipId', 'author', 'parentId'],
+  },
+  {
+    method: 'POST',
+    path: '/consent/ak_',
+    actionName: 'CREATE_CONSENT',
+    relevantFields: ['author', 'scope', 'status'],
+  },
+  {
+    method: 'POST',
+    path: /\/notification\/\d+/,
+    actionName: 'MODIFY_NOTIFICATION',
+    relevantFields: ['author', 'status'],
+  },
+  {
+    method: 'POST',
+    path: /\/notification\/?$/,
+    actionName: 'MODIFY_NOTIFICATION',
+    relevantFields: ['author', 'status', 'ids'],
+  },
+  {
+    method: 'POST',
+    path: '/profile/?$',
+    actionName: 'CREATE_PROFILE',
+    relevantFields: ['author', 'biography', 'preferredChainName', 'image', 'referrer', 'coverImage', 'location'],
+    getFullEntry: async req => Profile.findOne({ where: { author: req.body.author }, raw: true }),
+  },
+  {
+    method: 'POST',
+    path: '/profile/ak_',
+    actionName: 'UPDATE_PROFILE',
+    relevantFields: ['author', 'biography', 'preferredChainName', 'image', 'referrer', 'coverImage', 'location'],
+    getFullEntry: async req => Profile.findOne({ where: { author: req.params.author }, raw: true }),
+  },
+  {
+    method: 'POST',
+    path: '/profile/image/ak_',
+    actionName: 'CREATE_PROFILE',
+    relevantFields: ['author', 'biography', 'preferredChainName', 'image', 'referrer', 'coverImage', 'location'],
+    getFullEntry: async req => Profile.findOne({ where: { author: req.params.author }, raw: true }),
+  },
+  {
+    method: 'POST',
+    path: '/blacklist/api/wallet',
+    actionName: 'CREATE_FLAGGED_TIP',
+    relevantFields: ['tipId', 'author'],
+  },
+  {
+    method: 'POST',
+    path: '/pin/ak_',
+    actionName: 'CREATE_PIN',
+    relevantFields: ['author', 'entryId', 'type'],
+  },
+  {
+    method: 'DELETE',
+    path: '/pin/ak_',
+    actionName: 'DELETE_PIN',
+    relevantFields: ['author', 'entryId', 'type'],
+  },
+  {
+    method: 'DELETE',
+    path: '/comment/api/.*',
+    actionName: 'DELETE_COMMENT',
+    relevantFields: ['author'],
+  },
+  {
+    method: 'DELETE',
+    path: '/consent/ak_.*',
+    actionName: 'DELETE_PROFILE',
+    relevantFields: [],
+  },
+  {
+    method: 'DELETE',
+    path: '/profile/ak_.*',
+    actionName: 'DELETE_PROFILE',
+    relevantFields: [],
+  },
+  {
+    method: 'DELETE',
+    path: '/profile/image/ak_.*',
+    actionName: 'DELETE_PROFILE_IMAGE',
+    relevantFields: [],
+  }];
+
+module.exports = ACTIONS;

--- a/modules/authentication/logic/authenticationLogic.js
+++ b/modules/authentication/logic/authenticationLogic.js
@@ -3,224 +3,125 @@ const { v4: uuidv4 } = require('uuid');
 const urlParser = require('url');
 const imageLogic = require('../../media/logic/imageLogic');
 
-const { Profile } = require('../../../models');
 const logger = require('../../../utils/logger')(module);
-
-const VERSION = '2-0-0';
-
-const basicAuth = (req, res, next) => {
-  const auth = { login: process.env.AUTHENTICATION_USER, password: process.env.AUTHENTICATION_PASSWORD };
-  const b64auth = (req.headers.authorization || '').split(' ')[1] || '';
-  const [login, password] = Buffer.from(b64auth, 'base64').toString().split(':');
-
-  if (login && password && login === auth.login && password === auth.password) {
-    return next();
-  }
-
-  // Access denied...
-  res.set('WWW-Authenticate', 'Basic realm="Please enter user and password."'); // change this
-  return res.status(401).send('Authentication required.'); // custom message
-};
+const actions = require('../constants/actions');
 
 const MemoryQueue = [];
-const actions = [
-  {
-    method: 'GET',
-    path: '/notification/user/ak_',
-    actionName: 'GET_NOTIFICATIONS',
-    relevantFields: ['author'],
-  },
-  {
-    method: 'GET',
-    path: '/consent/ak_',
-    actionName: 'GET_CONSENT',
-    relevantFields: ['author'],
-  },
-  {
-    method: 'POST',
-    path: '/comment/api/?',
-    actionName: 'CREATE_COMMENT',
-    relevantFields: ['text', 'tipId', 'author', 'parentId'],
-  },
-  {
-    method: 'POST',
-    path: '/consent/ak_',
-    actionName: 'CREATE_CONSENT',
-    relevantFields: ['author', 'scope', 'status'],
-  },
-  {
-    method: 'POST',
-    path: /\/notification\/\d+/,
-    actionName: 'MODIFY_NOTIFICATION',
-    relevantFields: ['author', 'status'],
-  },
-  {
-    method: 'POST',
-    path: /\/notification\/?$/,
-    actionName: 'MODIFY_NOTIFICATION',
-    relevantFields: ['author', 'status', 'ids'],
-  },
-  {
-    method: 'POST',
-    path: '/profile/?$',
-    actionName: 'CREATE_PROFILE',
-    relevantFields: ['author', 'biography', 'preferredChainName', 'image', 'referrer', 'coverImage', 'location'],
-    getFullEntry: async req => Profile.findOne({ where: { author: req.body.author }, raw: true }),
-  },
-  {
-    method: 'POST',
-    path: '/profile/ak_',
-    actionName: 'UPDATE_PROFILE',
-    relevantFields: ['author', 'biography', 'preferredChainName', 'image', 'referrer', 'coverImage', 'location'],
-    getFullEntry: async req => Profile.findOne({ where: { author: req.params.author }, raw: true }),
-  },
-  {
-    method: 'POST',
-    path: '/profile/image/ak_',
-    actionName: 'CREATE_PROFILE',
-    relevantFields: ['author', 'biography', 'preferredChainName', 'image', 'referrer', 'coverImage', 'location'],
-    getFullEntry: async req => Profile.findOne({ where: { author: req.params.author }, raw: true }),
-  },
-  {
-    method: 'POST',
-    path: '/blacklist/api/wallet',
-    actionName: 'CREATE_FLAGGED_TIP',
-    relevantFields: ['tipId', 'author'],
-  },
-  {
-    method: 'POST',
-    path: '/pin/ak_',
-    actionName: 'CREATE_PIN',
-    relevantFields: ['author', 'entryId', 'type'],
-  },
-  {
-    method: 'DELETE',
-    path: '/pin/ak_',
-    actionName: 'DELETE_PIN',
-    relevantFields: ['author', 'entryId', 'type'],
-  },
-  {
-    method: 'DELETE',
-    path: '/comment/api/.*',
-    actionName: 'DELETE_COMMENT',
-    relevantFields: ['author'],
-  },
-  {
-    method: 'DELETE',
-    path: '/consent/ak_.*',
-    actionName: 'DELETE_PROFILE',
-    relevantFields: [],
-  },
-  {
-    method: 'DELETE',
-    path: '/profile/ak_.*',
-    actionName: 'DELETE_PROFILE',
-    relevantFields: [],
-  },
-  {
-    method: 'DELETE',
-    path: '/profile/image/ak_.*',
-    actionName: 'DELETE_PROFILE_IMAGE',
-    relevantFields: [],
-  }];
+const VERSION = '2-0-0';
 
-const signatureAuth = async (req, res, next) => {
-  const sendError = message => res.status(401).send({ err: message });
+const authenticationLogic = {
+  async basicAuth(req, res, next) {
+    const auth = { login: process.env.AUTHENTICATION_USER, password: process.env.AUTHENTICATION_PASSWORD };
+    const b64auth = (req.headers.authorization || '').split(' ')[1] || '';
+    const [login, password] = Buffer.from(b64auth, 'base64').toString().split(':');
 
-  // Filter expired items (10 mins timer)
-  // use delete to avoid race condition while overwriting
-  MemoryQueue.forEach(({ timestamp, file }, index) => {
-    if (timestamp < Date.now() - 5 * 60 * 1000) {
-      delete MemoryQueue[index];
+    if (login && password && login === auth.login && password === auth.password) {
+      return next();
+    }
+
+    // Access denied...
+    res.set('WWW-Authenticate', 'Basic realm="Please enter user and password."'); // change this
+    return res.status(401).send('Authentication required.'); // custom message
+  },
+
+  async signatureAuth(req, res, next) {
+    const sendError = message => res.status(401).send({ err: message });
+
+    // Filter expired items (10 mins timer)
+    // use delete to avoid race condition while overwriting
+    MemoryQueue.forEach(({ timestamp, file }, index) => {
+      if (timestamp < Date.now() - 5 * 60 * 1000) {
+        delete MemoryQueue[index];
+        try {
+          if (file) imageLogic.deleteImage(file.filename);
+        } catch (e) {
+          logger.error(`Could not delete file:${e.message}`);
+        }
+      }
+    });
+    const { signature, challenge } = { ...req.body, ...req.params, ...req.query };
+
+    if (signature || challenge) {
       try {
-        if (file) imageLogic.deleteImage(file.filename);
+        if (!signature) return sendError('Missing field signature');
+        if (!challenge) return sendError('Missing field challenge');
+
+        // Find item
+        // MemoryQueue probably has a significant list deleted items
+        const queueItem = MemoryQueue.find(item => (item || {}).challenge === challenge);
+        if (!queueItem) return sendError('Could not find challenge (maybe it already expired?)');
+        const {
+          challenge: originalChallenge, body, files, method, url,
+        } = queueItem;
+
+        // Verify that the challenge was issued for this method + path
+        if (req.method !== method) return sendError('Challenge was issued for a different http method');
+        if (urlParser.parse(req.originalUrl).pathname !== url) return sendError('Challenge was issued for a different path');
+
+        // The public key can either be
+        // body.author --> Comment route or POST profile
+        // params.author --> profile route
+        // we have to verify req.params.author first
+        const publicKey = req.params.author ? req.params.author : body.author;
+        if (!publicKey) sendError('Could not find associated public key');
+        const author = decodeBase58Check(publicKey.substring(3));
+
+        const authString = Buffer.from(originalChallenge);
+        const signatureArray = Uint8Array.from(Buffer.from(signature, 'hex'));
+
+        const validRequest = verifyPersonalMessage(authString, signatureArray, author);
+        if (validRequest) {
+          // Remove challenge from active queue
+          const queueIndex = MemoryQueue.findIndex(item => (item || {}).challenge === req.body.challenge);
+          delete MemoryQueue[queueIndex];
+          // forward request and merge current body onto existing
+          req.body = { ...{ signature, challenge }, ...body };
+          if (files) req.files = files;
+          return next();
+        }
+        return sendError('Invalid signature');
+      } catch (err) {
+        return sendError(err.message);
+      }
+    } else {
+      if (!req.body.author && !req.params.author) return sendError('Missing field author in body or url');
+      const uuid = uuidv4();
+      try {
+        const action = actions
+          .find(({ method, path: currentPath }) => method === req.method && req.originalUrl.match(currentPath));
+        if (!action) return sendError('Could not find valid action related to this request');
+
+        const { actionName, relevantFields, getFullEntry } = action;
+        const existingEntry = getFullEntry ? await getFullEntry(req) : {};
+        const files = req.files ? Object.keys(req.files).reduce((acc, curr) => {
+          acc[curr] = hash(imageLogic.readImage(req.files[curr][0].filename)).toString('hex');
+          return acc;
+        }, {}) : {};
+        const mergedObject = {
+          author: req.params.author, ...existingEntry, ...req.body, ...files,
+        };
+        const payload = relevantFields.reduce((acc, fieldIndex) => `${acc};${fieldIndex}=${mergedObject[fieldIndex]}`, '');
+
+        // UUID-RelevantFieldHash-Action-Timestamp
+        const newChallenge = `${uuid}-${hash(payload).toString('hex')}-${actionName}-${Date.now()}-${VERSION}`;
+        MemoryQueue.push({
+          challenge: newChallenge,
+          body: req.body,
+          method: req.method,
+          url: urlParser.parse(req.originalUrl).pathname,
+          files: req.files ? req.files : null,
+          timestamp: Date.now(),
+        });
+        return res.send({
+          challenge: newChallenge,
+          payload,
+        });
       } catch (e) {
-        logger.error(`Could not delete file:${e.message}`);
+        logger.error(e);
+        return sendError(e.message);
       }
     }
-  });
-  const { signature, challenge } = { ...req.body, ...req.params, ...req.query };
-
-  if (signature || challenge) {
-    try {
-      if (!signature) return sendError('Missing field signature');
-      if (!challenge) return sendError('Missing field challenge');
-
-      // Find item
-      // MemoryQueue probably has a significant list deleted items
-      const queueItem = MemoryQueue.find(item => (item || {}).challenge === challenge);
-      if (!queueItem) return sendError('Could not find challenge (maybe it already expired?)');
-      const {
-        challenge: originalChallenge, body, files, method, url,
-      } = queueItem;
-
-      // Verify that the challenge was issued for this method + path
-      if (req.method !== method) return sendError('Challenge was issued for a different http method');
-      if (urlParser.parse(req.originalUrl).pathname !== url) return sendError('Challenge was issued for a different path');
-
-      // The public key can either be
-      // body.author --> Comment route or POST profile
-      // params.author --> profile route
-      // we have to verify req.params.author first
-      const publicKey = req.params.author ? req.params.author : body.author;
-      if (!publicKey) sendError('Could not find associated public key');
-      const author = decodeBase58Check(publicKey.substring(3));
-
-      const authString = Buffer.from(originalChallenge);
-      const signatureArray = Uint8Array.from(Buffer.from(signature, 'hex'));
-
-      const validRequest = verifyPersonalMessage(authString, signatureArray, author);
-      if (validRequest) {
-        // Remove challenge from active queue
-        const queueIndex = MemoryQueue.findIndex(item => (item || {}).challenge === req.body.challenge);
-        delete MemoryQueue[queueIndex];
-        // forward request and merge current body onto existing
-        req.body = { ...{ signature, challenge }, ...body };
-        if (files) req.files = files;
-        return next();
-      }
-      return sendError('Invalid signature');
-    } catch (err) {
-      return sendError(err.message);
-    }
-  } else {
-    if (!req.body.author && !req.params.author) return sendError('Missing field author in body or url');
-    const uuid = uuidv4();
-    try {
-      const action = actions
-        .find(({ method, path: currentPath }) => method === req.method && req.originalUrl.match(currentPath));
-      if (!action) return sendError('Could not find valid action related to this request');
-
-      const { actionName, relevantFields, getFullEntry } = action;
-      const existingEntry = getFullEntry ? await getFullEntry(req) : {};
-      const files = req.files ? Object.keys(req.files).reduce((acc, curr) => {
-        acc[curr] = hash(imageLogic.readImage(req.files[curr][0].filename)).toString('hex');
-        return acc;
-      }, {}) : {};
-      const mergedObject = {
-        author: req.params.author, ...existingEntry, ...req.body, ...files,
-      };
-      const payload = relevantFields.reduce((acc, fieldIndex) => `${acc};${fieldIndex}=${mergedObject[fieldIndex]}`, '');
-
-      // UUID-RelevantFieldHash-Action-Timestamp
-      const newChallenge = `${uuid}-${hash(payload).toString('hex')}-${actionName}-${Date.now()}-${VERSION}`;
-      MemoryQueue.push({
-        challenge: newChallenge,
-        body: req.body,
-        method: req.method,
-        url: urlParser.parse(req.originalUrl).pathname,
-        files: req.files ? req.files : null,
-        timestamp: Date.now(),
-      });
-      return res.send({
-        challenge: newChallenge,
-        payload,
-      });
-    } catch (e) {
-      logger.error(e);
-      return sendError(e.message);
-    }
-  }
+  },
 };
 /**
  * @swagger
@@ -252,7 +153,5 @@ const signatureAuth = async (req, res, next) => {
  *       name: NOT-A-REAL-KEY
  *       description: This endpoint requires signature authentication. Swagger is insufficient here. Check the docs.
  */
-module.exports = {
-  basicAuth,
-  signatureAuth,
-};
+
+module.exports = authenticationLogic;

--- a/modules/backup/logic/backupLogic.js
+++ b/modules/backup/logic/backupLogic.js
@@ -3,15 +3,17 @@ const imageLogic = require('../../media/logic/imageLogic');
 const { IPFSEntry } = require('../../../models');
 const { IPFS_TYPES } = require('../constants/ipfsTypes');
 
-module.exports = class BackupLogic {
-  static async backupImageToIPFS(filename, publicKey, type) {
-    const buffer = imageLogic.readImage(filename);
-    const result = await ipfs.addFile(buffer);
-    if (!IPFS_TYPES[type]) throw TypeError(`Unknown type: ${type}`);
-    return IPFSEntry.create({
-      type,
-      hash: result.path,
-      reference: publicKey,
-    });
-  }
+async function backupImageToIPFS(filename, publicKey, type) {
+  const buffer = imageLogic.readImage(filename);
+  const result = await ipfs.addFile(buffer);
+  if (!IPFS_TYPES[type]) throw TypeError(`Unknown type: ${type}`);
+  return IPFSEntry.create({
+    type,
+    hash: result.path,
+    reference: publicKey,
+  });
+}
+
+module.exports = {
+  backupImageToIPFS,
 };

--- a/modules/backup/logic/backupLogic.js
+++ b/modules/backup/logic/backupLogic.js
@@ -3,17 +3,17 @@ const imageLogic = require('../../media/logic/imageLogic');
 const { IPFSEntry } = require('../../../models');
 const { IPFS_TYPES } = require('../constants/ipfsTypes');
 
-async function backupImageToIPFS(filename, publicKey, type) {
-  const buffer = imageLogic.readImage(filename);
-  const result = await ipfs.addFile(buffer);
-  if (!IPFS_TYPES[type]) throw TypeError(`Unknown type: ${type}`);
-  return IPFSEntry.create({
-    type,
-    hash: result.path,
-    reference: publicKey,
-  });
-}
-
-module.exports = {
-  backupImageToIPFS,
+const backupLogic = {
+  async backupImageToIPFS(filename, publicKey, type) {
+    const buffer = imageLogic.readImage(filename);
+    const result = await ipfs.addFile(buffer);
+    if (!IPFS_TYPES[type]) throw TypeError(`Unknown type: ${type}`);
+    return IPFSEntry.create({
+      type,
+      hash: result.path,
+      reference: publicKey,
+    });
+  },
 };
+
+module.exports = backupLogic;

--- a/modules/backup/logic/ipfsLogic.js
+++ b/modules/backup/logic/ipfsLogic.js
@@ -1,56 +1,61 @@
 const ipfsClient = require('ipfs-http-client');
 
-class IPFSLogic {
-  constructor() {
-    if (!process.env.IPFS_URL) throw new Error('IPFS_URL is not set');
-    this.node = ipfsClient(process.env.IPFS_URL);
-  }
-
-  static async asyncGeneratorToArray(generator) {
-    const all = [];
-    // eslint-disable-next-line no-restricted-syntax
-    for await (const result of generator) {
-      all.push(result);
-    }
-    return all;
-  }
-
-  async checkFileExists(hash) {
-    const result = await Promise.race([
-      this.node.files.stat(`/ipfs/${hash}`),
-      new Promise(resolve => {
-        setTimeout(() => {
-          resolve(null);
-        }, 1000);
-      }),
-    ]);
-    if (!result) return false;
-    return result.cid.toString() === hash;
-  }
-
-  async addFile(buffer) {
-    return this.node.add({
-      content: buffer,
-    });
-  }
-
-  async pinFile(hash) {
-    return this.node.pin.add(hash);
-  }
-
-  async getPinnedFiles() {
-    return IPFSLogic.asyncGeneratorToArray(this.node.pin.ls());
-  }
-
-  async getFile(hash) {
-    if (await this.checkFileExists(hash)) {
-      const data = await IPFSLogic.asyncGeneratorToArray(this.node.cat(hash));
-      return Buffer.concat(data);
-    }
-
-    throw Error(`IPFS: ${hash} not found`);
-  }
+let node;
+function init() {
+  if (!process.env.IPFS_URL) throw new Error('IPFS_URL is not set');
+  node = ipfsClient(process.env.IPFS_URL);
 }
 
-const ipfs = new IPFSLogic();
-module.exports = ipfs;
+async function asyncGeneratorToArray(generator) {
+  const all = [];
+  // eslint-disable-next-line no-restricted-syntax
+  for await (const result of generator) {
+    all.push(result);
+  }
+  return all;
+}
+
+async function checkFileExists(hash) {
+  const result = await Promise.race([
+    node.files.stat(`/ipfs/${hash}`),
+    new Promise(resolve => {
+      setTimeout(() => {
+        resolve(null);
+      }, 1000);
+    }),
+  ]);
+  if (!result) return false;
+  return result.cid.toString() === hash;
+}
+
+async function addFile(buffer) {
+  return node.add({
+    content: buffer,
+  });
+}
+
+async function pinFile(hash) {
+  return node.pin.add(hash);
+}
+
+async function getPinnedFiles() {
+  return asyncGeneratorToArray(node.pin.ls());
+}
+
+async function getFile(hash) {
+  if (await checkFileExists(hash)) {
+    const data = await asyncGeneratorToArray(node.cat(hash));
+    return Buffer.concat(data);
+  }
+
+  throw Error(`IPFS: ${hash} not found`);
+}
+
+module.exports = {
+  init,
+  checkFileExists,
+  addFile,
+  pinFile,
+  getPinnedFiles,
+  getFile,
+};

--- a/modules/backup/logic/ipfsLogic.js
+++ b/modules/backup/logic/ipfsLogic.js
@@ -6,6 +6,13 @@ function init() {
   node = ipfsClient(process.env.IPFS_URL);
 }
 
+async function getCoreVitals() {
+  return {
+    id: await node.id(),
+    version: await node.version(),
+  };
+}
+
 async function asyncGeneratorToArray(generator) {
   const all = [];
   // eslint-disable-next-line no-restricted-syntax
@@ -58,4 +65,5 @@ module.exports = {
   pinFile,
   getPinnedFiles,
   getFile,
+  getCoreVitals,
 };

--- a/modules/backup/tests/ipfs.js
+++ b/modules/backup/tests/ipfs.js
@@ -14,15 +14,11 @@ describe('IPFS', () => {
     let randomBuffer;
 
     before(done => {
+      ipfs.init();
       crypto.randomBytes(1000000, (err, buffer) => {
         randomBuffer = buffer;
         done();
       });
-    });
-
-    it('it should have a node property', done => {
-      ipfs.should.have.property('node');
-      done();
     });
 
     it('it should allow file upload', async function () {

--- a/modules/blacklist/logic/blacklistLogic.js
+++ b/modules/blacklist/logic/blacklistLogic.js
@@ -1,88 +1,65 @@
-const cache = require('../../cache/utils/cache');
+const CacheLogic = require('../../cache/logic/cacheLogic');
 const { BlacklistEntry } = require('../../../models');
 const { BLACKLIST_STATUS } = require('../constants/blacklistStates');
 
-module.exports = class Blacklist {
-  static async augmentAllItems(allItems) {
-    const blacklist = await BlacklistEntry.findAll({
-      raw: true,
-    });
-    return allItems.map(item => ({
-      ...item,
-      hidden: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.HIDDEN),
-      flagged: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.FLAGGED),
-    })).sort((a, b) => b.timestamp - a.timestamp);
-  }
+async function augmentAllItems(allItems) {
+  const blacklist = await BlacklistEntry.findAll({
+    raw: true,
+  });
+  return allItems.map(item => ({
+    ...item,
+    hidden: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.HIDDEN),
+    flagged: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.FLAGGED),
+  })).sort((a, b) => b.timestamp - a.timestamp);
+}
 
-  static async addItem(req, res) {
-    try {
-      const { tipId } = req.body;
-      if (!tipId) return res.status(400).send('Missing required field tipId');
-      const entry = await BlacklistEntry.create({ tipId: String(tipId) });
-      // Kill stats cache
-      await cache.del(['StaticLogic.getStats']);
-      await cache.del(['CacheLogic.getAllTips', 'blacklisted']);
-      return res.send(entry);
-    } catch (e) {
-      return res.status(500).send(e.message);
-    }
-  }
+async function resetCache() {
+  await CacheLogic.invalidateBlacklistedTips();
+  await CacheLogic.invalidateStatsCache();
+}
 
-  static async flagTip(req, res) {
-    try {
-      let { tipId } = req.body;
-      const { author } = req.body;
-      // Wallet sends tip as number
-      tipId = String(tipId);
-      if (!tipId) return res.status(400).send('Missing required field tipId');
-      if (!author) return res.status(400).send('Missing required field author');
-      let existingEntry = await BlacklistEntry.findOne({ where: { tipId } });
-      if (!existingEntry) {
-        existingEntry = await BlacklistEntry.create({ tipId, flagger: author, status: BLACKLIST_STATUS.FLAGGED });
-        // Kill stats cache
-        await cache.del(['StaticLogic.getStats']);
-        await cache.del(['CacheLogic.getAllTips', 'blacklisted']);
-      }
-      return res.send(existingEntry.toJSON());
-    } catch (e) {
-      return res.status(500).send(e.message);
-    }
-  }
+async function addItem(tipId) {
+  const entry = await BlacklistEntry.create({ tipId: String(tipId) });
 
-  static async updateItem(req, res) {
-    try {
-      const { status } = req.body;
-      const { tipId } = req.params;
-      if (!tipId) return res.status(400).send('Missing required field tipId');
-      if (!status) return res.status(400).send('Missing required field status');
-      await BlacklistEntry.update({ status }, { where: { tipId } });
-      return res.sendStatus(200);
-    } catch (e) {
-      return res.status(500).send(e.message);
-    }
-  }
+  await resetCache();
+  return entry;
+}
 
-  static async removeItem(req, res) {
-    const result = await BlacklistEntry.destroy({
-      where: {
-        tipId: req.params.tipId,
-      },
-    });
-    await cache.del(['CacheLogic.getAllTips', 'blacklisted']);
-    return result === 1 ? res.sendStatus(200) : res.sendStatus(404);
+async function flagTip(tipId, author) {
+  let entry = await BlacklistEntry.findOne({ where: { tipId }, raw: true });
+  if (!entry) {
+    entry = await BlacklistEntry.create({ tipId, flagger: author, status: BLACKLIST_STATUS.FLAGGED });
+    // Kill stats cache
+    await resetCache();
   }
+  return entry;
+}
 
-  static async getAllItems(req, res) {
-    res.send(await BlacklistEntry.findAll({ raw: true }));
-  }
+async function updateItem(tipId, status) {
+  await BlacklistEntry.update({ status }, { where: { tipId } });
+  await resetCache();
+}
 
-  static async getSingleItem(req, res) {
-    const result = await BlacklistEntry.findOne({ where: { tipId: req.params.tipId } });
-    return result ? res.send(result.toJSON()) : res.sendStatus(404);
-  }
+async function removeItem(tipId) {
+  const result = await BlacklistEntry.destroy({
+    where: {
+      tipId,
+    },
+  });
+  await resetCache();
+  return result;
+}
 
-  static async getBlacklistedIds() {
-    const blacklist = await BlacklistEntry.findAll({ raw: true, where: { status: BLACKLIST_STATUS.HIDDEN } });
-    return blacklist.map(b => b.tipId);
-  }
+async function getBlacklistedIds() {
+  const blacklist = await BlacklistEntry.findAll({ raw: true, where: { status: BLACKLIST_STATUS.HIDDEN } });
+  return blacklist.map(b => b.tipId);
+}
+
+module.exports = {
+  augmentAllItems,
+  addItem,
+  flagTip,
+  updateItem,
+  removeItem,
+  getBlacklistedIds,
 };

--- a/modules/blacklist/logic/blacklistLogic.js
+++ b/modules/blacklist/logic/blacklistLogic.js
@@ -2,64 +2,59 @@ const CacheLogic = require('../../cache/logic/cacheLogic');
 const { BlacklistEntry } = require('../../../models');
 const { BLACKLIST_STATUS } = require('../constants/blacklistStates');
 
-async function augmentAllItems(allItems) {
-  const blacklist = await BlacklistEntry.findAll({
-    raw: true,
-  });
-  return allItems.map(item => ({
-    ...item,
-    hidden: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.HIDDEN),
-    flagged: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.FLAGGED),
-  })).sort((a, b) => b.timestamp - a.timestamp);
-}
+const BlacklistLogic = {
+  async augmentAllItems(allItems) {
+    const blacklist = await BlacklistEntry.findAll({
+      raw: true,
+    });
+    return allItems.map(item => ({
+      ...item,
+      hidden: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.HIDDEN),
+      flagged: blacklist.some(b => b.tipId === item.id && b.status === BLACKLIST_STATUS.FLAGGED),
+    })).sort((a, b) => b.timestamp - a.timestamp);
+  },
 
-async function resetCache() {
-  await CacheLogic.invalidateBlacklistedTips();
-  await CacheLogic.invalidateStatsCache();
-}
+  async resetCache() {
+    await CacheLogic.invalidateBlacklistedTips();
+    await CacheLogic.invalidateStatsCache();
+  },
 
-async function addItem(tipId) {
-  const entry = await BlacklistEntry.create({ tipId: String(tipId) });
+  async addItem(tipId) {
+    const entry = await BlacklistEntry.create({ tipId: String(tipId) });
 
-  await resetCache();
-  return entry;
-}
+    await BlacklistLogic.resetCache();
+    return entry;
+  },
 
-async function flagTip(tipId, author) {
-  let entry = await BlacklistEntry.findOne({ where: { tipId }, raw: true });
-  if (!entry) {
-    entry = await BlacklistEntry.create({ tipId, flagger: author, status: BLACKLIST_STATUS.FLAGGED });
-    // Kill stats cache
-    await resetCache();
-  }
-  return entry;
-}
+  async flagTip(tipId, author) {
+    let entry = await BlacklistEntry.findOne({ where: { tipId }, raw: true });
+    if (!entry) {
+      entry = await BlacklistEntry.create({ tipId, flagger: author, status: BLACKLIST_STATUS.FLAGGED });
+      // Kill stats cache
+      await BlacklistLogic.resetCache();
+    }
+    return entry;
+  },
 
-async function updateItem(tipId, status) {
-  await BlacklistEntry.update({ status }, { where: { tipId } });
-  await resetCache();
-}
+  async updateItem(tipId, status) {
+    await BlacklistEntry.update({ status }, { where: { tipId } });
+    await BlacklistLogic.resetCache();
+  },
 
-async function removeItem(tipId) {
-  const result = await BlacklistEntry.destroy({
-    where: {
-      tipId,
-    },
-  });
-  await resetCache();
-  return result;
-}
+  async removeItem(tipId) {
+    const result = await BlacklistEntry.destroy({
+      where: {
+        tipId,
+      },
+    });
+    await BlacklistLogic.resetCache();
+    return result;
+  },
 
-async function getBlacklistedIds() {
-  const blacklist = await BlacklistEntry.findAll({ raw: true, where: { status: BLACKLIST_STATUS.HIDDEN } });
-  return blacklist.map(b => b.tipId);
-}
-
-module.exports = {
-  augmentAllItems,
-  addItem,
-  flagTip,
-  updateItem,
-  removeItem,
-  getBlacklistedIds,
+  async getBlacklistedIds() {
+    const blacklist = await BlacklistEntry.findAll({ raw: true, where: { status: BLACKLIST_STATUS.HIDDEN } });
+    return blacklist.map(b => b.tipId);
+  },
 };
+
+module.exports = BlacklistLogic;

--- a/modules/blacklist/routes/blacklistRoutes.js
+++ b/modules/blacklist/routes/blacklistRoutes.js
@@ -1,5 +1,5 @@
 const { Router } = require('express');
-const { BlacklistEntry } = require('sequelize');
+const { BlacklistEntry } = require('../../../models');
 const Logic = require('../logic/blacklistLogic');
 const CacheLogic = require('../../cache/logic/cacheLogic');
 const { basicAuth, signatureAuth } = require('../../authentication/logic/authenticationLogic');

--- a/modules/blacklist/tests/blacklist.js
+++ b/modules/blacklist/tests/blacklist.js
@@ -22,7 +22,7 @@ describe('Blacklist', () => {
     }).then(() => done());
   });
 
-  const tipId = 1;
+  const tipId = '1_v0';
 
   describe('Blacklist API', () => {
     it('it should GET all the blacklist entries (empty)', done => {
@@ -55,7 +55,7 @@ describe('Blacklist', () => {
 
     it('it should CREATE a new blacklist entry via wallet auth', done => {
       performSignedJSONRequest(server, 'post', '/blacklist/api/wallet/', {
-        tipId: tipId + 1, author: publicKey,
+        tipId: '1_v1', author: publicKey,
       }).then(({ res }) => {
         res.should.have.status(200);
         done();

--- a/modules/cache/logic/cacheLogic.js
+++ b/modules/cache/logic/cacheLogic.js
@@ -321,6 +321,14 @@ module.exports = class CacheLogic {
     await cache.del(['CacheLogic.getAllTips', 'all']);
   }
 
+  static async invalidateBlacklistedTips() {
+    await cache.del(['CacheLogic.getAllTips', 'blacklisted']);
+  }
+
+  static async invalidateStatsCache() {
+    await cache.del(['StaticLogic.getStats']);
+  }
+
   static async invalidateOracle() {
     await cache.del(['oracleState']);
   }

--- a/modules/cache/tests/cache.js
+++ b/modules/cache/tests/cache.js
@@ -40,22 +40,24 @@ describe('Cache', () => {
   };
   const minimalTimeout = 200;
 
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe('Keep Hot', () => {
     it('should update the cache (keep hot simulation)', async function () {
       this.timeout(15000);
       const messageStub = sinon.stub(queueLogic, 'sendMessage').callsFake(async () => {});
       await CacheLogic.getTips();
       sinon.assert.calledWith(messageStub, MESSAGE_QUEUES.CACHE, MESSAGES.CACHE.EVENTS.RENEWED_TIPS);
-      messageStub.restore();
     });
   });
 
   describe('API', () => {
     it('it should GET all cache items', function (done) {
       this.timeout(15000);
-      const messageStub = sinon.stub(queueLogic, 'sendMessage').callsFake(async () => {});
+      sinon.stub(queueLogic, 'sendMessage').callsFake(async () => {});
       checkCachedRoute('/cache/tips', 'array', () => {
-        messageStub.restore();
         done();
       });
     });
@@ -106,8 +108,6 @@ describe('Cache', () => {
       resTopic.body.should.have.length(1);
       resTopic.body[0].id.should.equal(1);
       stub.callCount.should.eql(3);
-
-      stub.restore();
     });
 
     it('it should GET all cache items with language filters', async () => {
@@ -165,8 +165,6 @@ describe('Cache', () => {
       resLanguageZHEN.body.should.have.length(4);
       resLanguageZHEN.body[0].id.should.equal('1_v1');
       stub.callCount.should.eql(3);
-
-      stub.restore();
     });
 
     it('it should GET all cache items with contractVersion filters', async () => {
@@ -208,12 +206,11 @@ describe('Cache', () => {
       resV2V3.body.should.have.length(2);
       resV2V3.body[0].id.should.equal('3_v2');
       stub.callCount.should.eql(3);
-
-      stub.restore();
     });
 
     it('it should not GET a flagged / blacklisted tip when requesting the full list', done => {
       const stub = sinon.stub(BlacklistLogic, 'getBlacklistedIds').callsFake(() => ['0_v1']);
+
       cache.del(['CacheLogic.getAllTips', 'blacklisted']);
       chai.request(server).get('/cache/tips').end((err, res) => {
         res.should.have.status(200);
@@ -359,9 +356,8 @@ describe('Cache', () => {
         },
       ];
 
-      const stub = sinon.stub(MdwLogic, 'middlewareContractTransactions').callsFake(async () => mockData);
+      sinon.stub(MdwLogic, 'middlewareContractTransactions').callsFake(async () => mockData);
       checkCachedRoute('/cache/events', 'array', () => {
-        stub.restore();
         done();
       });
     });

--- a/modules/health/logic/healthLogic.js
+++ b/modules/health/logic/healthLogic.js
@@ -23,8 +23,7 @@ module.exports = class HealthLogic {
 
   static async checkIPFSHealth() {
     try {
-      await ipfs.node.id();
-      await ipfs.node.version();
+      await ipfs.getCoreVitals();
       return true;
     } catch (e) {
       return false;

--- a/modules/token/routes/tokenCacheRoutes.js
+++ b/modules/token/routes/tokenCacheRoutes.js
@@ -183,7 +183,7 @@ router.get('/wordRegistry', wordbazaarMiddleware,
  *               type: object
  */
 router.get('/wordSale/:contractAddress', wordbazaarMiddleware,
-  async (req, res) => res.send(await CacheLogic.wordSaleDetails(req.params.contractAddress)));
+  async (req, res) => res.send(await CacheLogic.getWordSaleDetails(req.params.contractAddress)));
 
 /**
  * @swagger


### PR DESCRIPTION
refactoring:
- export singelton object instead of class instance
- remove express handlers from logic files
- moves constants to constants folder

minor fixes:
- fixed a bug where empty events would crash the decoding
